### PR TITLE
Updated to the latest version of VSCodium.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <a href="https://portapps.io/app/vscodium-portable/#download"><img src="https://img.shields.io/github/release/portapps/vscodium-portable.svg?style=flat-square" alt="GitHub release"></a>
   <a href="https://portapps.io/app/vscodium-portable/#download"><img src="https://img.shields.io/github/downloads/portapps/vscodium-portable/total.svg?style=flat-square" alt="Total downloads"></a>
-  <a href="https://github.com/eloiselle/vscodium-portable/actions?workflow=build"><img src="https://img.shields.io/github/actions/workflow/status/portapps/vscodium-portable/build.yml?label=build&logo=github&style=flat-square" alt="Build Status"></a>
+  <a href="https://github.com/portapps/vscodium-portable/actions?workflow=build"><img src="https://img.shields.io/github/actions/workflow/status/portapps/vscodium-portable/build.yml?label=build&logo=github&style=flat-square" alt="Build Status"></a>
   <a href="https://goreportcard.com/report/github.com/portapps/vscodium-portable"><img src="https://goreportcard.com/badge/github.com/portapps/vscodium-portable?style=flat-square" alt="Go Report"></a>
   <br /><a href="https://github.com/sponsors/crazy-max"><img src="https://img.shields.io/badge/sponsor-crazy--max-181717.svg?logo=github&style=flat-square" alt="Become a sponsor"></a>
   <a href="https://www.paypal.me/crazyws"><img src="https://img.shields.io/badge/donate-paypal-00457c.svg?logo=paypal&style=flat-square" alt="Donate Paypal"></a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-i<p align="center"><a href="https://portapps.io/app/vscodium-portable/" target="_blank"><img width="100" src="https://github.com/portapps/vscodium-portable/blob/master/res/papp.png"></a></p>
+<p align="center"><a href="https://portapps.io/app/vscodium-portable/" target="_blank"><img width="100" src="https://github.com/portapps/vscodium-portable/blob/master/res/papp.png"></a></p>
 
 <p align="center">
   <a href="https://portapps.io/app/vscodium-portable/#download"><img src="https://img.shields.io/github/release/portapps/vscodium-portable.svg?style=flat-square" alt="GitHub release"></a>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-<p align="center"><a href="https://portapps.io/app/vscodium-portable/" target="_blank"><img width="100" src="https://github.com/portapps/vscodium-portable/blob/master/res/papp.png"></a></p>
+i<p align="center"><a href="https://portapps.io/app/vscodium-portable/" target="_blank"><img width="100" src="https://github.com/portapps/vscodium-portable/blob/master/res/papp.png"></a></p>
 
 <p align="center">
   <a href="https://portapps.io/app/vscodium-portable/#download"><img src="https://img.shields.io/github/release/portapps/vscodium-portable.svg?style=flat-square" alt="GitHub release"></a>
   <a href="https://portapps.io/app/vscodium-portable/#download"><img src="https://img.shields.io/github/downloads/portapps/vscodium-portable/total.svg?style=flat-square" alt="Total downloads"></a>
-  <a href="https://github.com/portapps/vscodium-portable/actions?workflow=build"><img src="https://img.shields.io/github/actions/workflow/status/portapps/vscodium-portable/build.yml?label=build&logo=github&style=flat-square" alt="Build Status"></a>
+  <a href="https://github.com/eloiselle/vscodium-portable/actions?workflow=build"><img src="https://img.shields.io/github/actions/workflow/status/portapps/vscodium-portable/build.yml?label=build&logo=github&style=flat-square" alt="Build Status"></a>
   <a href="https://goreportcard.com/report/github.com/portapps/vscodium-portable"><img src="https://goreportcard.com/badge/github.com/portapps/vscodium-portable?style=flat-square" alt="Go Report"></a>
   <br /><a href="https://github.com/sponsors/crazy-max"><img src="https://img.shields.io/badge/sponsor-crazy--max-181717.svg?logo=github&style=flat-square" alt="Become a sponsor"></a>
   <a href="https://www.paypal.me/crazyws"><img src="https://img.shields.io/badge/donate-paypal-00457c.svg?logo=paypal&style=flat-square" alt="Donate Paypal"></a>

--- a/build.properties
+++ b/build.properties
@@ -5,8 +5,8 @@ core.dir = ../portapps
 app = vscodium
 app.name = VSCodium
 app.type = archive
-app.version = 1.82.2
-app.release = 160
+app.version = 1.73.1
+app.release = 56
 app.homepage = https://vscodium.com/
 
 # Portable app

--- a/build.properties
+++ b/build.properties
@@ -5,8 +5,8 @@ core.dir = ../portapps
 app = vscodium
 app.name = VSCodium
 app.type = archive
-app.version = 1.73.1
-app.release = 56
+app.version = 1.82.2
+app.release = 160
 app.homepage = https://vscodium.com/
 
 # Portable app

--- a/build.properties
+++ b/build.properties
@@ -5,8 +5,8 @@ core.dir = ../portapps
 app = vscodium
 app.name = VSCodium
 app.type = archive
-app.version = 1.73.1
-app.release = 56
+app.version = 1.82.2.23257
+app.release = 160
 app.homepage = https://vscodium.com/
 
 # Portable app
@@ -21,5 +21,5 @@ papp.folder = app
 atf.id = VSCodium
 atf.win64.filename = ${atf.id}-win64-${app.version}
 atf.win64.ext = .zip
-atf.win64.url = https://github.com/VSCodium/vscodium/releases/download/${app.version}.22314/VSCodium-win32-x64-${app.version}.22314.zip
+atf.win64.url = https://github.com/VSCodium/vscodium/releases/download/${app.version}/VSCodium-win32-x64-${app.version}.zip
 atf.win64.assertextract = VSCodium.exe


### PR DESCRIPTION
To be precise:

- VSCodium updated from version 1.73.1.22314 to 1.82.2.23257

The release on my fork also has Portapps updated from 3.6.0 to 3.8.0. However, since I'm not affiliated with Portapps, I don't have access to VirusTotal scans from their repository.